### PR TITLE
feat: add `/v2/sbom/{id}/license.zip` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8606,6 +8606,7 @@ dependencies = [
  "cpe",
  "criterion",
  "csaf",
+ "csv",
  "cve",
  "futures-util",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ cpe = "0.1.5"
 criterion = "0.5.1"
 csaf = { version = "0.5.0", default-features = false }
 csaf-walker = { version = "0.11.0", default-features = false }
+csv = "1.3.1"
 cve = "0.3.1"
 deepsize = "0.2.0"
 env_logger = "0.11.0"

--- a/modules/fundamental/Cargo.toml
+++ b/modules/fundamental/Cargo.toml
@@ -25,6 +25,7 @@ async-graphql = { workspace = true, features = ["uuid", "time"] }
 async-trait = { workspace = true }
 base64 = { workspace = true }
 cpe = { workspace = true }
+csv = { workspace = true }
 futures-util = { workspace = true }
 itertools = { workspace = true }
 lenient_semver = { workspace = true }
@@ -44,6 +45,7 @@ tracing = { workspace = true }
 utoipa = { workspace = true, features = ["actix_extras", "uuid", "time"] }
 utoipa-actix-web = { workspace = true }
 uuid = { workspace = true }
+zip = { workspace = true }
 
 [dev-dependencies]
 actix-http = { workspace = true }

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     purl::model::summary::purl::PurlSummary, source_document::model::SourceDocument, Error,
 };
 use async_graphql::SimpleObject;
-use sea_orm::{prelude::Uuid, ConnectionTrait, ModelTrait, PaginatorTrait};
+use sea_orm::{prelude::Uuid, ConnectionTrait, FromQueryResult, ModelTrait, PaginatorTrait};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use trustify_common::{cpe::Cpe, model::Paginated, purl::Purl};
@@ -168,4 +168,17 @@ pub enum Which {
     Left,
     /// Target side
     Right,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, FromQueryResult)]
+pub struct SbomPackageLicenseBase {
+    pub sbom_name: Option<String>,
+    pub sbom_namespace: Option<String>,
+    pub component_group: Option<String>,
+    pub component_version: Option<String>,
+    pub node_id: String,
+    pub sbom_id: Uuid,
+    pub package_name: String,
+    pub version: String,
+    pub license_text: Option<String>,
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1646,6 +1646,31 @@ paths:
           description: Modified the labels of the SBOM
         '404':
           description: The SBOM could not be found
+  /api/v2/sbom/{id}/license.zip:
+    get:
+      tags:
+      - sbom
+      operationId: licenseZip
+      parameters:
+      - name: id
+        in: path
+        description: Digest/hash of the document, prefixed by hash type, such as 'sha256:<hash>' or 'urn:uuid:<uuid>'
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: license zip file
+          content:
+            application/octet-stream:
+              schema:
+                type: array
+                items:
+                  type: integer
+                  format: int32
+                  minimum: 0
+        '404':
+          description: The document could not be found
   /api/v2/sbom/{id}/packages:
     get:
       tags:


### PR DESCRIPTION
Initial pass at adding an endpoint to get the license zip.   Still needs to also generate the 2nd file and lots of test assertions.