### PR TITLE
AI package_info_tool test: changed consistently the expected results

### DIFF
--- a/modules/fundamental/src/ai/service/tools/package_info.rs
+++ b/modules/fundamental/src/ai/service/tools/package_info.rs
@@ -239,9 +239,7 @@ mod tests {
   "name": "libsepol",
   "version": "3.5-1.el9",
   "advisories": [],
-  "licenses": [
-    "LGPLV2+"
-  ],
+  "licenses": [],
   "sboms": [
     {
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -263,9 +261,7 @@ mod tests {
   "name": "libsepol",
   "version": "3.5-1.el9",
   "advisories": [],
-  "licenses": [
-    "LGPLV2+"
-  ],
+  "licenses": [],
   "sboms": [
     {
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -287,9 +283,7 @@ mod tests {
   "name": "commons-logging-jboss-logging",
   "version": "1.0.0.Final-redhat-1",
   "advisories": [],
-  "licenses": [
-    "APACHE-2.0"
-  ],
+  "licenses": [],
   "sboms": [
     {
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -309,9 +303,7 @@ mod tests {
   "name": "commons-logging-jboss-logging",
   "version": "1.0.0.Final-redhat-1",
   "advisories": [],
-  "licenses": [
-    "APACHE-2.0"
-  ],
+  "licenses": [],
   "sboms": [
     {
       "uuid": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",


### PR DESCRIPTION
Changed the expected results for the test since we're, in this initial license implementation, not providing license data for packages, ref. https://github.com/trustification/trustify/discussions/1396#discussioncomment-12411524.
With these changes, locally all of the tests run successfully (i.e. `cargo test --all-features`).