### PR TITLE
Refactor sbom_name, sbom_namespace, package_name

### DIFF
--- a/modules/fundamental/src/license/endpoints/mod.rs
+++ b/modules/fundamental/src/license/endpoints/mod.rs
@@ -46,6 +46,7 @@ pub async fn get_license_export(
         fetcher.license_export(id, db.as_ref()).await?;
     if let Some(name_group_version) = sbom_name_version_group.clone() {
         let exporter = LicenseExporter::new(
+            name_group_version.sbom_namespace.clone(),
             name_group_version.sbom_name.clone(),
             name_group_version.sbom_group.clone(),
             name_group_version.sbom_version.clone(),

--- a/modules/fundamental/src/license/model/sbom_license.rs
+++ b/modules/fundamental/src/license/model/sbom_license.rs
@@ -4,9 +4,6 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, Default)]
 pub struct SbomPackageLicense {
-    pub sbom_namespace: Option<String>,
-    /// Package name
-    pub name: String,
     /// package package URL
     pub purl: Vec<Purl>,
     pub other_reference: Vec<trustify_entity::cpe::Model>,
@@ -28,16 +25,14 @@ pub struct Purl {
 
 #[derive(Debug, Clone, FromQueryResult)]
 pub struct SbomPackageLicenseBase {
-    pub sbom_name: Option<String>,
-    pub sbom_namespace: Option<String>,
     pub node_id: Option<String>,
     pub sbom_id: Uuid,
-    pub package_name: String,
     pub license_text: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, FromQueryResult)]
 pub struct SbomNameGroupVersion {
+    pub sbom_namespace: String,
     pub sbom_name: String,
     pub sbom_group: Option<String>,
     pub sbom_version: String,

--- a/modules/fundamental/src/license/service/license_export.rs
+++ b/modules/fundamental/src/license/service/license_export.rs
@@ -11,6 +11,7 @@ use tar::Builder;
 type CSVs = (Writer<Vec<u8>>, Writer<Vec<u8>>);
 
 pub struct LicenseExporter {
+    sbom_namespace: String,
     sbom_name: String,
     sbom_group: Option<String>,
     sbom_version: String,
@@ -20,6 +21,7 @@ pub struct LicenseExporter {
 
 impl LicenseExporter {
     pub fn new(
+        sbom_namespace: String,
         sbom_name: String,
         sbom_group: Option<String>,
         sbom_version: String,
@@ -27,6 +29,7 @@ impl LicenseExporter {
         extracted_licensing_infos: Vec<ExtractedLicensingInfos>,
     ) -> Self {
         LicenseExporter {
+            sbom_namespace,
             sbom_name,
             sbom_group,
             sbom_version,
@@ -143,10 +146,7 @@ impl LicenseExporter {
 
             wtr_sbom.write_record([
                 &self.sbom_name.clone(),
-                &package
-                    .sbom_namespace
-                    .clone()
-                    .unwrap_or_else(String::default),
+                &self.sbom_namespace.clone(),
                 &self.sbom_group.clone().unwrap_or_default(),
                 &self.sbom_version.clone(),
                 &purl_list,

--- a/modules/fundamental/src/license/service/mod.rs
+++ b/modules/fundamental/src/license/service/mod.rs
@@ -53,6 +53,7 @@ impl LicenseService {
                 package_relates_to_package::Relation::RightPackage.def(),
             )
             .select_only()
+            .column_as(sbom::Column::DocumentId, "sbom_namespace")
             .column_as(sbom_node::Column::Name, "sbom_name")
             .column_as(sbom_package::Column::Group, "sbom_group")
             .column_as(sbom_package::Column::Version, "sbom_version")
@@ -78,9 +79,7 @@ impl LicenseService {
             )
             .select_only()
             .column_as(sbom::Column::SbomId, "sbom_id")
-            .column_as(sbom::Column::DocumentId, "sbom_namespace")
             .column_as(sbom_package::Column::NodeId, "node_id")
-            .column_as(sbom_node::Column::Name, "package_name")
             .column_as(license::Column::Text, "license_text")
             .into_model::<SbomPackageLicenseBase>()
             .all(connection)
@@ -121,8 +120,6 @@ impl LicenseService {
                 .await?;
 
             sbom_package_list.push(SbomPackageLicense {
-                sbom_namespace: spl.sbom_namespace,
-                name: spl.package_name,
                 purl: result_purl,
                 other_reference: result_cpe,
                 license_text: spl.license_text,

--- a/modules/fundamental/tests/sbom/license.rs
+++ b/modules/fundamental/tests/sbom/license.rs
@@ -119,6 +119,7 @@ async fn test_license_export_spdx(ctx: &TrustifyContext) -> Result<(), anyhow::E
         let sbom_name_group_version =
             sbom_name_group_version.unwrap_or_else(SbomNameGroupVersion::default);
         let exporter = LicenseExporter::new(
+            sbom_name_group_version.sbom_namespace,
             sbom_name_group_version.sbom_name,
             sbom_name_group_version.sbom_group,
             sbom_name_group_version.sbom_version,
@@ -205,6 +206,7 @@ async fn test_license_export_cyclonedx(ctx: &TrustifyContext) -> Result<(), anyh
         let sbom_name_group_version =
             sbom_name_group_version.unwrap_or_else(SbomNameGroupVersion::default);
         let exporter = LicenseExporter::new(
+            sbom_name_group_version.sbom_namespace,
             sbom_name_group_version.sbom_name,
             sbom_name_group_version.sbom_group,
             sbom_name_group_version.sbom_version,


### PR DESCRIPTION
Refactored some fields:

- `package_name` was set but never read when creating the CSV so it has been removed (avoiding to read useless data from DB)
- `sbom_name` and `sbom_namespace` were read for each package (using `SbomPackageLicenseBase`) rather than just once per SBOM so they've been both moved into the `SbomNameGroupVersion` struct (`sbom_name` was already there) and the queries have been consistently updated
