### PR TITLE
feat: refactored license type management in CSV license export

### DIFF
--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -27,7 +27,7 @@ pub enum Relation {
     License,
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
+#[derive(Copy, Clone, Debug, strum::Display, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum LicenseCategory {
     Declared = 0,

--- a/modules/fundamental/src/license/model/sbom_license.rs
+++ b/modules/fundamental/src/license/model/sbom_license.rs
@@ -1,10 +1,8 @@
 use sea_orm::FromQueryResult;
-use trustify_entity::{
-    labels::Labels, qualified_purl::CanonicalPurl, sbom_package_license::LicenseCategory,
-};
+use trustify_entity::{qualified_purl::CanonicalPurl, sbom_package_license::LicenseCategory};
 use uuid::Uuid;
 
-#[derive(Debug, Clone, PartialEq, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct SbomPackageLicense {
     pub name: String,
     pub group: Option<String>,
@@ -12,24 +10,24 @@ pub struct SbomPackageLicense {
     /// package package URL
     pub purl: Vec<Purl>,
     pub cpe: Vec<trustify_entity::cpe::Model>,
-    /// List of all package license
-    pub license_declared_text: Option<String>,
-    pub license_concluded_text: Option<String>,
+    /// List of all package licenses with their types
+    pub license_text: Option<String>,
+    pub license_type: Option<LicenseCategory>,
 }
 
-#[derive(Debug, Clone, PartialEq, FromQueryResult)]
+#[derive(Debug, Clone, FromQueryResult)]
 pub struct Sbom {
     pub sbom_id: Uuid,
     pub node_id: String,
     pub sbom_namespace: String,
 }
 
-#[derive(Debug, Clone, PartialEq, FromQueryResult)]
+#[derive(Debug, Clone, FromQueryResult)]
 pub struct Purl {
     pub purl: CanonicalPurl,
 }
 
-#[derive(Debug, Clone, PartialEq, FromQueryResult)]
+#[derive(Debug, Clone, FromQueryResult)]
 pub struct SbomPackageLicenseBase {
     pub node_id: String,
     pub sbom_id: Uuid,
@@ -40,43 +38,16 @@ pub struct SbomPackageLicenseBase {
     pub license_type: Option<LicenseCategory>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, FromQueryResult)]
+#[derive(Debug, Clone, Default, FromQueryResult)]
 pub struct SbomNameId {
     pub sbom_name: String,
     pub sbom_id: String,
-    pub labels: Labels,
 }
 
-#[derive(Debug, Clone, PartialEq, FromQueryResult)]
+#[derive(Debug, Clone, FromQueryResult)]
 pub struct ExtractedLicensingInfos {
     pub license_id: String,
     pub name: String,
     pub extracted_text: String,
     pub comment: String,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct MergedSbomPackageLicense {
-    pub node_id: String,
-    pub sbom_id: Uuid,
-    pub name: String,
-    pub group: Option<String>,
-    pub version: Option<String>,
-    pub license_declared_text: Option<String>,
-    pub license_concluded_text: Option<String>,
-}
-
-impl MergedSbomPackageLicense {
-    pub fn apply_license(&mut self, license: &SbomPackageLicenseBase) {
-        if let Some(license_type) = &license.license_type {
-            match license_type {
-                LicenseCategory::Declared => {
-                    self.license_declared_text = license.license_text.clone();
-                }
-                LicenseCategory::Concluded => {
-                    self.license_concluded_text = license.license_text.clone();
-                }
-            }
-        }
-    }
 }

--- a/modules/fundamental/src/license/service/license_export.rs
+++ b/modules/fundamental/src/license/service/license_export.rs
@@ -10,6 +10,7 @@ use csv::{Writer, WriterBuilder};
 use flate2::{Compression, write::GzEncoder};
 use tar::Builder;
 use trustify_common::purl::Purl;
+use trustify_entity::sbom_package_license::LicenseCategory;
 
 type CSVs = (Writer<Vec<u8>>, Writer<Vec<u8>>);
 
@@ -111,8 +112,8 @@ impl LicenseExporter {
             "package version",
             "package purl",
             "package cpe",
-            "declared license",
-            "concluded license",
+            "license",
+            "license type",
         ])?;
 
         for extracted_licensing_info in self.extracted_licensing_infos {
@@ -135,7 +136,7 @@ impl LicenseExporter {
             let purl_list = package
                 .purl
                 .into_iter()
-                .map(|purl| format!("{}", Purl::from(purl.purl.clone())))
+                .map(|purl| format!("{}", Purl::from(purl.purl)))
                 .collect::<Vec<_>>()
                 .join("\n");
 
@@ -147,12 +148,11 @@ impl LicenseExporter {
                 &package.version.unwrap_or_default(),
                 &purl_list,
                 &alternate_package_reference,
+                &package.license_text.unwrap_or_else(String::default),
                 &package
-                    .license_declared_text
-                    .unwrap_or_else(String::default),
-                &package
-                    .license_concluded_text
-                    .unwrap_or_else(String::default),
+                    .license_type
+                    .unwrap_or(LicenseCategory::Declared)
+                    .to_string(),
             ])?;
         }
 


### PR DESCRIPTION
Here is the proposal for having a solution without relying upon the `labels` to identify the ingested SBOM format.

Instead of adding the `license concluded` column in the CSV export, I've added the `license type` column in order to keep in place the (already existing) "contract" that a package with multiple licenses has multiple rows in the CSV export, one for each license. Now this approach has been extended to have multiple rows for each package, one for each "license, license type" tuple.

Once applied the CSV export format change, I've also removed the unnecessary changes and updated the tests consistently: most of the expected numbers have doubled because now each package from an SPDX SBOM appears twice (one row the declared license and one for the concluded one).