### PR TITLE
TC-1902: license information JSON management

### DIFF
--- a/entity/src/sbom_package_license.rs
+++ b/entity/src/sbom_package_license.rs
@@ -1,4 +1,6 @@
 use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 #[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel)]
 #[sea_orm(table_name = "sbom_package_license")]
@@ -27,7 +29,19 @@ pub enum Relation {
     License,
 }
 
-#[derive(Copy, Clone, Debug, strum::Display, Eq, PartialEq, EnumIter, DeriveActiveEnum)]
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    strum::Display,
+    Eq,
+    PartialEq,
+    EnumIter,
+    DeriveActiveEnum,
+    Serialize,
+    Deserialize,
+    ToSchema,
+)]
 #[sea_orm(rs_type = "i32", db_type = "Integer")]
 pub enum LicenseCategory {
     Declared = 0,

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -33,7 +33,7 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
     }
 
     let result: Value = query_value(&app, &id, "name~logback-core").await;
-    let except_result = json!({
+    let expected_result = json!({
         "items": [
             {
                 "id": "pkg:maven/ch.qos.logback/logback-core@1.2.13?type=jar",
@@ -59,15 +59,18 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                     }
                 ],
                 "cpe": [],
-                "licenses": "[{\"type\": 0, \"expression\": \"EPL-1.0\"},{\"type\": 0, \"expression\": \"GNU Lesser General Public License\"}]"
+                "licenses": [
+                    {"license_type": 0, "license_name": "EPL-1.0"},
+                    {"license_type": 0, "license_name": "GNU Lesser General Public License"}
+                ]
             }
         ],
         "total": 1
     });
 
-    assert!(result.contains_subset(except_result));
+    assert!(result.contains_subset(expected_result));
     let result: Value = query_value(&app, &id, "name~logback-cor&Text~EPL").await;
-    let except_result = json!({
+    let expected_result = json!({
         "items": [
             {
                 "id": "pkg:maven/ch.qos.logback/logback-core@1.2.13?type=jar",
@@ -93,12 +96,14 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                     }
                 ],
                 "cpe": [],
-                "licenses": "[{\"type\": 0, \"expression\": \"EPL-1.0\"}]"
+                "licenses": [
+                    {"license_type": 0, "license_name": "EPL-1.0"}
+                ]
             }
         ],
         "total": 1
     });
-    assert!(result.contains_subset(except_result));
+    assert!(result.contains_subset(expected_result));
 
     let id = ctx
         .ingest_document("spdx/SATELLITE-6.15-RHEL-8.json")
@@ -107,7 +112,7 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
         .to_string();
 
     let result = query_value(&app, &id, "name=rubygem-coffee-script").await;
-    let except_result = json!({
+    let expected_result = json!({
         "items": [
             {
                 "id": "SPDXRef-02be9b35-a6ca-47b5-9c9e-9098c00ae212",
@@ -133,7 +138,10 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                     }
                 ],
                 "cpe": [],
-                "licenses": "[{\"type\": 0, \"expression\": \"MIT\"},{\"type\": 1, \"expression\": \"MIT\"}]"
+                "licenses": [
+                    {"license_type": 0, "license_name": "MIT"},
+                    {"license_type": 1, "license_name": "MIT"}
+                ]
             },
             {
                 "id": "SPDXRef-9fe51d0d-aec8-4a70-9bf0-70b60606632d",
@@ -165,12 +173,15 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                     "cpe:/a:redhat:satellite:6.12:*:el8:*",
                     "cpe:/a:redhat:satellite:6.13:*:el8:*"
                 ],
-                "licenses": "[{\"type\": 0, \"expression\": \"MIT\"},{\"type\": 1, \"expression\": \"MIT\"}]"
+                "licenses": [
+                    {"license_type": 0, "license_name": "MIT"},
+                    {"license_type": 1, "license_name": "MIT"}
+                ]
             }
         ],
         "total": 2
     });
-    assert!(result.contains_subset(except_result));
+    assert!(result.contains_subset(expected_result));
     Ok(())
 }
 

--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -60,8 +60,8 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                 ],
                 "cpe": [],
                 "licenses": [
-                    {"license_type": 0, "license_name": "EPL-1.0"},
-                    {"license_type": 0, "license_name": "GNU Lesser General Public License"}
+                    {"license_type": "Declared", "license_name": "EPL-1.0"},
+                    {"license_type": "Declared", "license_name": "GNU Lesser General Public License"}
                 ]
             }
         ],
@@ -97,7 +97,7 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                 ],
                 "cpe": [],
                 "licenses": [
-                    {"license_type": 0, "license_name": "EPL-1.0"}
+                    {"license_type": "Declared", "license_name": "EPL-1.0"}
                 ]
             }
         ],
@@ -139,8 +139,8 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                 ],
                 "cpe": [],
                 "licenses": [
-                    {"license_type": 0, "license_name": "MIT"},
-                    {"license_type": 1, "license_name": "MIT"}
+                    {"license_type": "Declared", "license_name": "MIT"},
+                    {"license_type": "Concluded", "license_name": "MIT"}
                 ]
             },
             {
@@ -174,8 +174,8 @@ async fn get_packages_sbom_by_query(ctx: &TrustifyContext) -> Result<(), anyhow:
                     "cpe:/a:redhat:satellite:6.13:*:el8:*"
                 ],
                 "licenses": [
-                    {"license_type": 0, "license_name": "MIT"},
-                    {"license_type": 1, "license_name": "MIT"}
+                    {"license_type": "Declared", "license_name": "MIT"},
+                    {"license_type": "Concluded", "license_name": "MIT"}
                 ]
             }
         ],

--- a/modules/fundamental/src/sbom/model/details.rs
+++ b/modules/fundamental/src/sbom/model/details.rs
@@ -212,7 +212,7 @@ impl SbomAdvisory {
                 version: each.sbom_package.version,
                 purl: vec![PurlSummary::from_entity(&each.qualified_purl)],
                 cpe: vec![],
-                licenses: None,
+                licenses: vec![],
             });
         }
 

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -118,7 +118,13 @@ pub struct SbomPackage {
     /// CPEs identifying the package
     pub cpe: Vec<String>,
     /// License info
-    pub licenses: Option<String>,
+    pub licenses: Vec<LicenseBasicInfo>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject)]
+pub struct LicenseBasicInfo {
+    pub(crate) license_name: String,
+    pub(crate) license_type: i32,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     Error, purl::model::summary::purl::PurlSummary, source_document::model::SourceDocument,
 };
 use async_graphql::SimpleObject;
+use sea_orm::FromJsonQueryResult;
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -121,10 +122,12 @@ pub struct SbomPackage {
     pub licenses: Vec<LicenseBasicInfo>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject)]
+#[derive(
+    Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema, SimpleObject, FromJsonQueryResult,
+)]
 pub struct LicenseBasicInfo {
-    pub(crate) license_name: String,
-    pub(crate) license_type: i32,
+    pub license_name: String,
+    pub license_type: i32,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -29,7 +29,7 @@ async fn ingest_spdx_medium(ctx: &TrustifyContext) -> Result<(), anyhow::Error> 
                     version: Some("4.8.z".to_string()),
                     purl: vec![],
                     cpe: vec!["cpe:/a:redhat:openshift_container_storage:4.8:*:el8:*".into()],
-                    licenses: None,
+                    licenses: vec![],
                 }
             );
 
@@ -101,7 +101,7 @@ async fn ingest_spdx_medium_cpes(ctx: &TrustifyContext) -> Result<(), anyhow::Er
                     version: Some("9.2.0".to_string()),
                     purl: vec![],
                     cpe: vec![],
-                    licenses: None,
+                    licenses: vec![],
                 }
             );
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3677,6 +3677,17 @@ components:
       type: object
       additionalProperties:
         type: string
+    LicenseBasicInfo:
+      type: object
+      required:
+      - license_name
+      - license_type
+      properties:
+        license_name:
+          type: string
+        license_type:
+          type: integer
+          format: int32
     LicenseSummary:
       type: object
       required:
@@ -4057,6 +4068,7 @@ components:
             - name
             - purl
             - cpe
+            - licenses
             properties:
               cpe:
                 type: array
@@ -4072,9 +4084,9 @@ components:
                 type: string
                 description: The SBOM internal ID of a package
               licenses:
-                type:
-                - string
-                - 'null'
+                type: array
+                items:
+                  $ref: '#/components/schemas/LicenseBasicInfo'
                 description: License info
               name:
                 type: string
@@ -4602,6 +4614,7 @@ components:
       - name
       - purl
       - cpe
+      - licenses
       properties:
         cpe:
           type: array
@@ -4617,9 +4630,9 @@ components:
           type: string
           description: The SBOM internal ID of a package
         licenses:
-          type:
-          - string
-          - 'null'
+          type: array
+          items:
+            $ref: '#/components/schemas/LicenseBasicInfo'
           description: License info
         name:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3677,7 +3677,12 @@ components:
       type: object
       additionalProperties:
         type: string
-    LicenseBasicInfo:
+    LicenseCategory:
+      type: string
+      enum:
+      - Declared
+      - Concluded
+    LicenseInfo:
       type: object
       required:
       - license_name
@@ -3686,8 +3691,7 @@ components:
         license_name:
           type: string
         license_type:
-          type: integer
-          format: int32
+          $ref: '#/components/schemas/LicenseCategory'
     LicenseSummary:
       type: object
       required:
@@ -4086,7 +4090,7 @@ components:
               licenses:
                 type: array
                 items:
-                  $ref: '#/components/schemas/LicenseBasicInfo'
+                  $ref: '#/components/schemas/LicenseInfo'
                 description: License info
               name:
                 type: string
@@ -4632,7 +4636,7 @@ components:
         licenses:
           type: array
           items:
-            $ref: '#/components/schemas/LicenseBasicInfo'
+            $ref: '#/components/schemas/LicenseInfo'
           description: License info
         name:
           type: string


### PR DESCRIPTION
So, rather than managing the `licenses` field as an `Option<String>` that contains a JSON, I've tried to manage it as a JSON properly, creating the `LicenseBasicInfo` struct to manage the mapping and changing accordingly the SQL query.
Also the OpenAPI definition benefit from this change because now the output has a clearly defined structure, i.e. `license_name` and `license_type` fields.
The changes in the tests reflect the new approach and so also the expected results are now proper JSON rather than a String.

@bxf12315 and @ctron please have both a look to this PR so that, once merged, things can be improved, e.g. is `LicenseBasicInfo` in the right place or should it moved somewhere else? Or shouldn't it be better to map the `license_type` from `i32` to the corresponding `LicenseCategory` string value?