### PR TITLE
chore: listAllLicenseIds by SBOM Id rather than Uuid

### DIFF
--- a/modules/fundamental/src/sbom/endpoints/test.rs
+++ b/modules/fundamental/src/sbom/endpoints/test.rs
@@ -92,8 +92,15 @@ async fn fetch_unique_licenses(ctx: &TrustifyContext) -> Result<(), anyhow::Erro
     }
     log::debug!("{response:#?}");
 
-    let uri = "/api/v2/sbom/sha256:e5c850b67868563002801668950832278f8093308b3a3c57931f591442ed3160/all-license-ids".to_string();
-    let req = TestRequest::get().uri(&uri).to_request();
+    // properly formatted but not existent Id
+    let req = TestRequest::get().uri("/api/v2/sbom/sha256:e5c850b67868563002801668950832278f8093308b3a3c57931f591442ed3160/all-license-ids").to_request();
+    let response = app.call_service(req).await;
+    assert_eq!(StatusCode::NOT_FOUND, response.status());
+
+    // badly formatted Id
+    let req = TestRequest::get()
+        .uri("/api/v2/sbom/sha123:1234/all-license-ids")
+        .to_request();
     let response = app.call_service(req).await;
     assert_eq!(StatusCode::BAD_REQUEST, response.status());
     Ok(())

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2467,7 +2467,7 @@ paths:
     get:
       tags:
       - sbom
-      operationId: allLicenseIds
+      operationId: listAllLicenseIds
       parameters:
       - name: id
         in: path


### PR DESCRIPTION
So I've further improved the implementation in the base PR https://github.com/trustification/trustify/pull/1706 to fully leverage the capabilities in the `Id` to find the SBOM. This implied having a two steps approach where the first step is now to find the `Sbom` and then use its `sbom_id` in the previously available query.
In this context I've added a test to cover the `404` response in case the SBOM has not been found by the provided (and well formatted) `Id`.

I've also seen some other endpoints have the `list` prefix in the `operation_id` field when they are meant to get resources so I changed it here accordingly.
