### PR TITLE
TC-2826: refactored LicenseInfo

### DIFF
--- a/modules/fundamental/src/common/mod.rs
+++ b/modules/fundamental/src/common/mod.rs
@@ -1,5 +1,8 @@
+use crate::sbom::service::sbom::LicenseBasicInfo;
 use sea_orm::FromQueryResult;
+use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
+use trustify_entity::sbom_package_license::LicenseCategory;
 use utoipa::ToSchema;
 
 pub mod service;
@@ -8,4 +11,19 @@ pub mod service;
 pub struct LicenseRefMapping {
     pub license_id: String,
     pub license_name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
+pub struct LicenseInfo {
+    pub license_name: String,
+    pub license_type: LicenseCategory,
+}
+
+impl From<LicenseBasicInfo> for LicenseInfo {
+    fn from(license_basic_info: LicenseBasicInfo) -> Self {
+        LicenseInfo {
+            license_name: license_basic_info.license_name,
+            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
+        }
+    }
 }

--- a/modules/fundamental/src/purl/endpoints/test.rs
+++ b/modules/fundamental/src/purl/endpoints/test.rs
@@ -281,11 +281,11 @@ async fn test_purl_license_details(ctx: &TrustifyContext) -> Result<(), anyhow::
       "licenses": [
         {
           "license_name": "(LicenseRef-8 OR LicenseRef-0 OR LicenseRef-MPL) AND (LicenseRef-Netscape OR LicenseRef-0 OR LicenseRef-8)",
-          "license_type": "Declared"
+          "license_type": "declared"
         },
         {
           "license_name": "NOASSERTION",
-          "license_type": "Concluded"
+          "license_type": "concluded"
         }
       ],
       "license_ref_mapping": [

--- a/modules/fundamental/src/sbom/model/mod.rs
+++ b/modules/fundamental/src/sbom/model/mod.rs
@@ -2,19 +2,18 @@ pub mod details;
 pub mod raw_sql;
 
 use super::service::SbomService;
+use crate::common::LicenseInfo;
 use crate::{
     Error, common::LicenseRefMapping, purl::model::summary::purl::PurlSummary,
-    sbom::service::sbom::LicenseBasicInfo, source_document::model::SourceDocument,
+    source_document::model::SourceDocument,
 };
 use sea_orm::{ConnectionTrait, ModelTrait, PaginatorTrait, prelude::Uuid};
-use sea_query::FromValueTuple;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 use tracing::instrument;
 use trustify_common::{cpe::Cpe, purl::Purl};
 use trustify_entity::{
-    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package,
-    sbom_package_license::LicenseCategory, source_document,
+    labels::Labels, relationship::Relationship, sbom, sbom_node, sbom_package, source_document,
 };
 use utoipa::ToSchema;
 
@@ -133,21 +132,6 @@ pub struct SbomPackage {
     /// LicenseRef mappings
     #[cfg_attr(feature = "async-graphql", graphql(skip))]
     pub licenses_ref_mapping: Vec<LicenseRefMapping>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, ToSchema)]
-pub struct LicenseInfo {
-    pub license_name: String,
-    pub license_type: LicenseCategory,
-}
-
-impl From<LicenseBasicInfo> for LicenseInfo {
-    fn from(license_basic_info: LicenseBasicInfo) -> Self {
-        LicenseInfo {
-            license_name: license_basic_info.license_name,
-            license_type: LicenseCategory::from_value_tuple(license_basic_info.license_type),
-        }
-    }
 }
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]

--- a/modules/fundamental/tests/sbom/spdx/perf.rs
+++ b/modules/fundamental/tests/sbom/spdx/perf.rs
@@ -4,7 +4,7 @@ use test_log::test;
 use tracing::instrument;
 use trustify_common::model::Paginated;
 use trustify_entity::sbom_package_license::LicenseCategory;
-use trustify_module_fundamental::sbom::model::{LicenseInfo, SbomPackage};
+use trustify_module_fundamental::{common::LicenseInfo, sbom::model::SbomPackage};
 use trustify_test_context::TrustifyContext;
 
 #[test_context(TrustifyContext)]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4663,7 +4663,7 @@ components:
           licenses:
             type: array
             items:
-              $ref: '#/components/schemas/PurlLicenseInfo'
+              $ref: '#/components/schemas/LicenseInfo'
           version:
             $ref: '#/components/schemas/VersionedPurlHead'
     PurlHead:
@@ -4679,16 +4679,6 @@ components:
           type: string
           format: uuid
           description: The ID of the qualified PURL
-    PurlLicenseInfo:
-      type: object
-      required:
-      - license_name
-      - license_type
-      properties:
-        license_name:
-          type: string
-        license_type:
-          type: string
     PurlStatus:
       type: object
       required:


### PR DESCRIPTION
- refactored already existing `LicenseInfo` struct to reuse the code and give consistency in licenses management. Hence removed `PurlLicenseInfo` (benefit also for OpenAPI definitions)
- refactored `PurlLicenseResult`
- fix `test_purl_license_details` to expected `license_type` values consistent with values already returned from the sbom packages call
- moved from raw SQL to SeaORM statement
  - removed unused `qualified_package_id` and `license_id` columns
  - removed the ordering as unclear the benefit of having it considering the data are then manipulated